### PR TITLE
Replaces printf with print

### DIFF
--- a/wp-fragment-cache.php
+++ b/wp-fragment-cache.php
@@ -153,7 +153,7 @@ abstract class WP_Fragment_Cache {
 		}
 
 		if( true === $also_output ) {
-			printf( $contents );
+			print( $contents );
 		}
 
 		return $contents;


### PR DESCRIPTION
Printf requires a format and a string. This one is just given a string. Only print is needed.